### PR TITLE
3.1.3 SDK updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
update affdexsdk dependencies to use dynamic versioning with value
of "3.+", which will cause the sample apps to pick up the highest-numbered
SDK release in the 3.x series.  This way we won't need to update the samples
when we do a point release.

update gradle plugin to 2.2.2

set all versionCode values to 1 (normally a Bad Thing if you're app is
published to the Play store, but these aren't, so simpler to just have it
this way)

set APK naming style to appname-version-build#